### PR TITLE
Update docker to last stable docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@ Azure_ArangoDB_Cluster.sh
 DigitalOcean_ArangoDB_Cluster.sh
 GoogleComputeEngine_ArangoDB_Cluster.sh
 GoogleComputeEngine_Mesos_Cluster.sh
+vCloud_ArangoDB_Cluster.sh
 digital_ocean/
 azure/
 gce/
 aws/
+*.swp

--- a/Docker/ArangoDBClusterWithDocker.sh
+++ b/Docker/ArangoDBClusterWithDocker.sh
@@ -195,7 +195,7 @@ startArangoDBClusterWithDocker() {
     wait
 
     echo Starting agency...
-    until $SSH_CMD "${SSH_ARGS}" ${SSH_USER}@${SERVERS_EXTERNAL_ARR[0]} $SSH_SUFFIX "docker run --detach=true -e ARANGO_NO_AUTH=1 -p 4001:8529 --name=agency -v $AGENCY_DIR:/var/lib/arangodb3 ${DOCKER_IMAGE_NAME}  --server.authentication false --agency.id 0 --agency.size 1 --javascript.v8-contexts 2"
+    until $SSH_CMD "${SSH_ARGS}" ${SSH_USER}@${SERVERS_EXTERNAL_ARR[0]} $SSH_SUFFIX "docker run --detach=true -e ARANGO_NO_AUTH=1 -p 4001:8529 --name=agency -v $AGENCY_DIR:/var/lib/arangodb3 ${DOCKER_IMAGE_NAME} --agency.id 0 --agency.size 1 --javascript.v8-contexts 2 --agency.supervision true"
     do
         echo "Error in remote docker run, retrying..."
     done

--- a/platformAWS/AmazonWebServices_ArangoDB_Cluster.sh
+++ b/platformAWS/AmazonWebServices_ArangoDB_Cluster.sh
@@ -143,42 +143,43 @@ fi
 
 #We have to keep all ami's up to date
 # Current Version: CoreOS 607.0.0
-# URL: https://coreos.com/docs/running-coreos/cloud-providers/ec2/
+# mop: updated 2016-02-08 CoreOS CoreOS 835.12.0
+# URL: https://coreos.com/os/docs/latest/booting-on-ec2.html
 
 if [ "$zone" == "eu-central-1" ]; then
-  IMAGE="ami-0e300d13"
+  IMAGE="ami-e8ebf384"
 fi
 
 if [ "$zone" == "ap-northeast-1" ]; then
-  IMAGE="ami-af28dcaf"
+  IMAGE="ami-673b0109"
 fi
 
 if [ "$zone" == "sa-east-1" ]; then
-  IMAGE="ami-2354ec3e"
+  IMAGE="ami-6c1a9a00"
 fi
 
 if [ "$zone" == "ap-southeast-2" ]; then
-  IMAGE="ami-b9b5c583"
+  IMAGE="ami-d0a783b3"
 fi
 
 if [ "$zone" == "ap-southeast-1" ]; then
-  IMAGE="mi-f80b3aaa"
+  IMAGE="ami-4a65aa29"
 fi
 
 if [ "$zone" == "us-east-1" ]; then
-  IMAGE="ami-323b195a"
+  IMAGE="ami-dfb699b5"
 fi
 
 if [ "$zone" == "us-west-2" ]; then
-  IMAGE="ami-0789a437"
+  IMAGE="ami-abc82ecb"
 fi
 
 if [ "$zone" == "us-west-1" ]; then
-  IMAGE="ami-8dd533c9"
+  IMAGE="ami-4d2d5b2d"
 fi
 
 if [ "$zone" == "eu-west-1" ]; then
-  IMAGE="ami-55950a22"
+  IMAGE="ami-1461d767"
 fi
 
 
@@ -337,7 +338,7 @@ function setMachineName () {
 function setMachineSecurity () {
   echo "Adding security groups."
   id=`cat "$OUTPUT/temp/IDS$i"`
-  secureid=`aws ec2 describe-security-groups --output json --group-names ${PREFIX}security |python -mjson.tool|grep GroupId| awk {'print $2'}| cut -c 2- | rev | cut -c 3- | rev`
+  secureid=$(aws ec2 describe-security-groups --output json --group-names ${PREFIX}security | grep GroupId | sed -e "s/.*: \"\([^\"]\+\).*/\1/g")
   aws ec2 modify-instance-attribute --instance-id "$id" --groups "$secureid"
 }
 

--- a/platformAWS/AmazonWebServices_ArangoDB_Cluster.sh
+++ b/platformAWS/AmazonWebServices_ArangoDB_Cluster.sh
@@ -338,7 +338,7 @@ function setMachineName () {
 function setMachineSecurity () {
   echo "Adding security groups."
   id=`cat "$OUTPUT/temp/IDS$i"`
-  secureid=$(aws ec2 describe-security-groups --output json --group-names ${PREFIX}security | grep GroupId | sed -e "s/.*: \"\([^\"]\+\).*/\1/g")
+  secureid=$(aws ec2 describe-security-groups --output json --group-names ${PREFIX}security | grep GroupId | sed -e 's/.*: "\([^"]*\)"/\1/g')
   aws ec2 modify-instance-attribute --instance-id "$id" --groups "$secureid"
 }
 

--- a/platformAZURE/Azure_ArangoDB_Cluster.sh
+++ b/platformAZURE/Azure_ArangoDB_Cluster.sh
@@ -12,11 +12,11 @@
 
 trap "kill 0" SIGINT
 
-ZONE="West US"
+ZONE="West Europe"
 MACHINE_TYPE="Medium"
 NUMBER="3"
 OUTPUT="azure"
-IMAGE="2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-607.0.0"
+IMAGE="2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-835.12.0"
 SSH_KEY_PATH=""
 DEFAULT_KEY_PATH="$OUTPUT/arangodb_azure_key"
 
@@ -165,7 +165,7 @@ then
     DEFAULT_KEY_PATH="$HOME/.ssh/arangodb_azure_key"
   else
     echo "No SSH-Key-Path given. Creating a new SSH-Key."
-    ssh-keygen -t dsa -f "$DEFAULT_KEY_PATH" -C "arangodb@arangodb.com"
+    ssh-keygen -t rsa -f "$DEFAULT_KEY_PATH" -C "arangodb@arangodb.com"
 
 #    openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout "$DEFAULT_KEY_PATH" -out "$DEFAULT_KEY_PATH.pem"
     openssl req -x509 -key "$DEFAULT_KEY_PATH" -nodes -days 365 -newkey rsa:2048 -out "${DEFAULT_KEY_PATH}.pem"

--- a/platformDO/DigitalOcean_ArangoDB_Cluster.sh
+++ b/platformDO/DigitalOcean_ArangoDB_Cluster.sh
@@ -192,7 +192,7 @@ if test -z "$SSHID";  then
 
   then
     echo "No ArangoDB SSH-Key found. Generating a new one.!"
-    ssh-keygen -t dsa -f $OUTPUT/$SSH_KEY -C "arangodb@arangodb.com"
+    ssh-keygen -t rsa -f $OUTPUT/$SSH_KEY -C "arangodb@arangodb.com"
 
     if [ $? -eq 0 ]; then
       echo OK

--- a/platformGCE/GoogleComputeEngine_ArangoDB_Cluster.sh
+++ b/platformGCE/GoogleComputeEngine_ArangoDB_Cluster.sh
@@ -375,7 +375,7 @@ export SERVERS_EXTERNAL
 export SERVERS_IDS
 export SSH_USER="core"
 export SSH_CMD="ssh"
-export SSH_SUFFIX="-i $DEFAULT_KEY_PATH -l $SSH_USER"
+export SSH_SUFFIX=""
 export ZONE
 export PROJECT
 export DBSERVER_DATA=/data/dbserver


### PR DESCRIPTION
Hi all,

I want to use this project to clone the clustered infrastructure into our software hosted in GCE (Google Cloud Engine).
I ran the script and it worked, but, unfortunatelly, I saw that the version of arango was too old: I'm using last version (2.8.3) instead 2.6.x in this branch.

Can you suggest me a patch or create for me a branch with the new docker url of the last stable version of arango (and the changes needed)? I've seen this branch, but I don't know if in this branch the version of arango is the last stable or the last dev.

Thank you very much.

Daniele
